### PR TITLE
Change defualt values of secret permissions to correct casing

### DIFF
--- a/infrastructure/terraform/01-inputs-shared.tf
+++ b/infrastructure/terraform/01-inputs-shared.tf
@@ -16,10 +16,10 @@ variable "sp_object_id" {
 variable "secret_permissions" {
   description = "The permissions (list) for the creating principal accessing secrets."
   default = [
-    "get",
-    "set",
-    "list",
-    "delete"
+    "Get",
+    "Set",
+    "List",
+    "Delete"
   ]
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Changing default values of `secret_permissions` field in 'azurerm_key_vault_access_policy' to be compatible with new version of Terraform. (https://docs.microsoft.com/en-us/azure/developer/terraform/provider-version-history-azurerm)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
