### PR TITLE
Hmis 1064 feature

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/resources/ResourcesAPITest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/resources/ResourcesAPITest.java
@@ -47,7 +47,7 @@ public class ResourcesAPITest extends FunctionalTest {
     @Steps
     ResourcesSteps resourceSteps;
 
-    @Test
+//    @Test Commented out as the API has been removed from ListAssist. HMIS-1081 will delete this test.
     public void testRequestUserWithEmptyPayload() {
         log.debug("In the testRequestAndAmendAResourceByUser() method");
         resourceSteps.shouldCreateOrAmendUserWithInvalidPayload(resourcesByUserRootContext,
@@ -56,7 +56,7 @@ public class ResourcesAPITest extends FunctionalTest {
                 "{}");
     }
 
-    @Test
+//    @Test Commented out as the API has been removed from ListAssist. HMIS-1081 will delete this test.
     public void testRequestLocationWithEmptyPayload() {
         resourceSteps.shouldCreateOrAmendLocationWithInvalidPayload(resourcesByLocationRootContext,
                 headersAsMap,
@@ -64,7 +64,7 @@ public class ResourcesAPITest extends FunctionalTest {
                 "{}");
     }
 
-    @Test
+//    @Test Commented out as the API has been removed from ListAssist. HMIS-1081 will delete this test.
     public void testAmendLocationWithEmptyPayload() {
         int randomId = new Random().nextInt(99999999);
         resourcesByLocation_idRootContext = String.format(resourcesByLocation_idRootContext,randomId);


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1064

### Change description ###
HMIS-1064 Comment out failed tests affected by the removal of the APIs from services from ListAssist at McGirr side. So the master build can be green. HMIS-1081 will delete any affected tests in the future.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
