### PR TITLE
Hmis 1123 dev

### DIFF
--- a/infrastructure/template/api-op-crime-health-policy.xml
+++ b/infrastructure/template/api-op-crime-health-policy.xml
@@ -12,8 +12,8 @@
     <outbound>
         <base />
         <choose>
-            <when condition="@(context.Response.StatusCode != 200)">
-                <cache-remove-value key="vhAuth" />
+            <when condition="@(context.Response.StatusCode == 404 || context.Response.StatusCode == 403 || context.Response.StatusCode == 503 || context.Response.StatusCode == 401 || context.Response.StatusCode == 400)">
+                <cache-remove-value key="CrimeAuth" />
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
                     <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>

--- a/infrastructure/template/api-op-crime-health-policy.xml
+++ b/infrastructure/template/api-op-crime-health-policy.xml
@@ -11,6 +11,38 @@
     </backend>
     <outbound>
         <base />
+        <when condition="@(context.Response.StatusCode != 200)">
+            <cache-remove-value key="vhAuth" />
+            <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                <set-method>GET</set-method>
+                <authentication-managed-identity resource="https://vault.azure.net" />
+            </send-request>
+            <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
+                <set-method>POST</set-method>
+                <set-header name="Authorization" exists-action="override">
+                    <value>
+                        @("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As<JObject>()["value"].ToString())
+                    </value>
+                </set-header>
+                <set-body>@{
+                    return new JObject(
+                    new JProperty("assignment_group", ""),
+                    new JProperty("caller_id", ""),
+                    new JProperty("category", "Data Issue"),
+                    new JProperty("contact_type", "Alert"),
+                    new JProperty("description", "HMI Health Check Endpoint Error")),
+                    new JProperty("impact", "2"),
+                    new JProperty("service_offering", ""),
+                    new JProperty("short_description", "HMI - API Gateway Error"),
+                    new JProperty("subcategory", "HMI - Backend Service Failure"),
+                    new JProperty("u_role_type", ""),
+                    new JProperty("urgency", "")
+                    ).ToString();
+                    }</set-body>
+            </send-request>
+        </when>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-crime-health-policy.xml
+++ b/infrastructure/template/api-op-crime-health-policy.xml
@@ -12,34 +12,32 @@
     <outbound>
         <base />
         <choose>
-            <when condition="@(context.Response.StatusCode == 404 || context.Response.StatusCode == 403 || context.Response.StatusCode == 503 || context.Response.StatusCode == 401 || context.Response.StatusCode == 400)">
-                <cache-remove-value key="CrimeAuth" />
+            <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
-                        <value>
-                            @("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As<JObject>()["value"].ToString())
-                        </value>
+                        <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As
+                            <JObject>()["value"].ToString())</value>
                     </set-header>
                     <set-body>@{
                         return new JObject(
-                        new JProperty("assignment_group", ""),
-                        new JProperty("caller_id", ""),
+                        new JProperty("assignment_group", "56b756774fbd368057db0b318110c7bd"),
+                        new JProperty("caller_id", "1475a0491b743414f0dc85e4464bcb7a"),
                         new JProperty("category", "Data Issue"),
                         new JProperty("contact_type", "Alert"),
-                        new JProperty("description", "HMI Health Check Endpoint Error")),
+                        new JProperty("description", "Crime Health Endpoint is Down"),
                         new JProperty("impact", "2"),
-                        new JProperty("service_offering", ""),
+                        new JProperty("service_offering", "138e0c541bc5bc507bdaddf0b24bcb2a"),
                         new JProperty("short_description", "HMI - API Gateway Error"),
                         new JProperty("subcategory", "HMI - Backend Service Failure"),
-                        new JProperty("u_role_type", ""),
-                        new JProperty("urgency", "")
+                        new JProperty("u_role_type", "c319bc4bdb41834074abffa9bf96199c"),
+                        new JProperty("urgency", "3")
                         ).ToString();
                         }</set-body>
                 </send-request>

--- a/infrastructure/template/api-op-crime-health-policy.xml
+++ b/infrastructure/template/api-op-crime-health-policy.xml
@@ -11,38 +11,40 @@
     </backend>
     <outbound>
         <base />
-        <when condition="@(context.Response.StatusCode != 200)">
-            <cache-remove-value key="vhAuth" />
-            <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
-                <set-method>GET</set-method>
-                <authentication-managed-identity resource="https://vault.azure.net" />
-            </send-request>
-            <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
-                <set-method>POST</set-method>
-                <set-header name="Authorization" exists-action="override">
-                    <value>
-                        @("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As<JObject>()["value"].ToString())
-                    </value>
-                </set-header>
-                <set-body>@{
-                    return new JObject(
-                    new JProperty("assignment_group", ""),
-                    new JProperty("caller_id", ""),
-                    new JProperty("category", "Data Issue"),
-                    new JProperty("contact_type", "Alert"),
-                    new JProperty("description", "HMI Health Check Endpoint Error")),
-                    new JProperty("impact", "2"),
-                    new JProperty("service_offering", ""),
-                    new JProperty("short_description", "HMI - API Gateway Error"),
-                    new JProperty("subcategory", "HMI - Backend Service Failure"),
-                    new JProperty("u_role_type", ""),
-                    new JProperty("urgency", "")
-                    ).ToString();
-                    }</set-body>
-            </send-request>
-        </when>
+        <choose>
+            <when condition="@(context.Response.StatusCode != 200)">
+                <cache-remove-value key="vhAuth" />
+                <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-method>GET</set-method>
+                    <authentication-managed-identity resource="https://vault.azure.net" />
+                </send-request>
+                <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>
+                            @("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As<JObject>()["value"].ToString())
+                        </value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                        new JProperty("assignment_group", ""),
+                        new JProperty("caller_id", ""),
+                        new JProperty("category", "Data Issue"),
+                        new JProperty("contact_type", "Alert"),
+                        new JProperty("description", "HMI Health Check Endpoint Error")),
+                        new JProperty("impact", "2"),
+                        new JProperty("service_offering", ""),
+                        new JProperty("short_description", "HMI - API Gateway Error"),
+                        new JProperty("subcategory", "HMI - Backend Service Failure"),
+                        new JProperty("u_role_type", ""),
+                        new JProperty("urgency", "")
+                        ).ToString();
+                        }</set-body>
+                </send-request>
+            </when>
+        </choose>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-crime-health-policy.xml
+++ b/infrastructure/template/api-op-crime-health-policy.xml
@@ -14,12 +14,12 @@
         <choose>
             <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
                         <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As

--- a/infrastructure/template/api-op-elinks-health-policy.xml
+++ b/infrastructure/template/api-op-elinks-health-policy.xml
@@ -8,6 +8,38 @@
     </backend>
     <outbound>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode != 200)">
+                <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-method>GET</set-method>
+                    <authentication-managed-identity resource="https://vault.azure.net" />
+                </send-request>
+                <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As
+                            <JObject>()["value"].ToString())</value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                        new JProperty("assignment_group", "56b756774fbd368057db0b318110c7bd"),
+                        new JProperty("caller_id", "1475a0491b743414f0dc85e4464bcb7a"),
+                        new JProperty("category", "Data Issue"),
+                        new JProperty("contact_type", "Alert"),
+                        new JProperty("description", "elinks Health Endpoint is Down"),
+                        new JProperty("impact", "2"),
+                        new JProperty("service_offering", "138e0c541bc5bc507bdaddf0b24bcb2a"),
+                        new JProperty("short_description", "HMI - API Gateway Error"),
+                        new JProperty("subcategory", "HMI - Backend Service Failure"),
+                        new JProperty("u_role_type", "c319bc4bdb41834074abffa9bf96199c"),
+                        new JProperty("urgency", "3")
+                        ).ToString();
+                        }</set-body>
+                </send-request>
+            </when>
+        </choose>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-elinks-health-policy.xml
+++ b/infrastructure/template/api-op-elinks-health-policy.xml
@@ -11,12 +11,12 @@
         <choose>
             <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
                         <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As

--- a/infrastructure/template/api-op-publication-health-policy.xml
+++ b/infrastructure/template/api-op-publication-health-policy.xml
@@ -50,6 +50,38 @@
     </backend>
     <outbound>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode != 200)">
+                <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-method>GET</set-method>
+                    <authentication-managed-identity resource="https://vault.azure.net" />
+                </send-request>
+                <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As
+                            <JObject>()["value"].ToString())</value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                        new JProperty("assignment_group", "56b756774fbd368057db0b318110c7bd"),
+                        new JProperty("caller_id", "1475a0491b743414f0dc85e4464bcb7a"),
+                        new JProperty("category", "Data Issue"),
+                        new JProperty("contact_type", "Alert"),
+                        new JProperty("description", "P&I Health Endpoint is Down"),
+                        new JProperty("impact", "2"),
+                        new JProperty("service_offering", "138e0c541bc5bc507bdaddf0b24bcb2a"),
+                        new JProperty("short_description", "HMI - API Gateway Error"),
+                        new JProperty("subcategory", "HMI - Backend Service Failure"),
+                        new JProperty("u_role_type", "c319bc4bdb41834074abffa9bf96199c"),
+                        new JProperty("urgency", "3")
+                        ).ToString();
+                        }</set-body>
+                </send-request>
+            </when>
+        </choose>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-publication-health-policy.xml
+++ b/infrastructure/template/api-op-publication-health-policy.xml
@@ -53,12 +53,12 @@
         <choose>
             <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
                         <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As

--- a/infrastructure/template/api-op-snl-health-policy.xml
+++ b/infrastructure/template/api-op-snl-health-policy.xml
@@ -75,12 +75,12 @@
         <choose>
             <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
                         <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As

--- a/infrastructure/template/api-op-snl-health-policy.xml
+++ b/infrastructure/template/api-op-snl-health-policy.xml
@@ -72,6 +72,38 @@
     </backend>
     <outbound>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode != 200)">
+                <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-method>GET</set-method>
+                    <authentication-managed-identity resource="https://vault.azure.net" />
+                </send-request>
+                <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As
+                            <JObject>()["value"].ToString())</value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                        new JProperty("assignment_group", "56b756774fbd368057db0b318110c7bd"),
+                        new JProperty("caller_id", "1475a0491b743414f0dc85e4464bcb7a"),
+                        new JProperty("category", "Data Issue"),
+                        new JProperty("contact_type", "Alert"),
+                        new JProperty("description", "SNL Health Endpoint is Down"),
+                        new JProperty("impact", "2"),
+                        new JProperty("service_offering", "138e0c541bc5bc507bdaddf0b24bcb2a"),
+                        new JProperty("short_description", "HMI - API Gateway Error"),
+                        new JProperty("subcategory", "HMI - Backend Service Failure"),
+                        new JProperty("u_role_type", "c319bc4bdb41834074abffa9bf96199c"),
+                        new JProperty("urgency", "3")
+                        ).ToString();
+                        }</set-body>
+                </send-request>
+            </when>
+        </choose>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-vh-health-policy.xml
+++ b/infrastructure/template/api-op-vh-health-policy.xml
@@ -8,6 +8,38 @@
     </backend>
     <outbound>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode != 200)">
+                <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
+                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-method>GET</set-method>
+                    <authentication-managed-identity resource="https://vault.azure.net" />
+                </send-request>
+                <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
+                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-method>POST</set-method>
+                    <set-header name="Authorization" exists-action="override">
+                        <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As
+                            <JObject>()["value"].ToString())</value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                        new JProperty("assignment_group", "56b756774fbd368057db0b318110c7bd"),
+                        new JProperty("caller_id", "1475a0491b743414f0dc85e4464bcb7a"),
+                        new JProperty("category", "Data Issue"),
+                        new JProperty("contact_type", "Alert"),
+                        new JProperty("description", "VH Health Endpoint is Down"),
+                        new JProperty("impact", "2"),
+                        new JProperty("service_offering", "138e0c541bc5bc507bdaddf0b24bcb2a"),
+                        new JProperty("short_description", "HMI - API Gateway Error"),
+                        new JProperty("subcategory", "HMI - Backend Service Failure"),
+                        new JProperty("u_role_type", "c319bc4bdb41834074abffa9bf96199c"),
+                        new JProperty("urgency", "3")
+                        ).ToString();
+                        }</set-body>
+                </send-request>
+            </when>
+        </choose>
     </outbound>
     <on-error>
         <base />

--- a/infrastructure/template/api-op-vh-health-policy.xml
+++ b/infrastructure/template/api-op-vh-health-policy.xml
@@ -11,12 +11,12 @@
         <choose>
             <when condition="@(context.Response.StatusCode != 200)">
                 <send-request ignore-error="true" timeout="20" response-variable-name="snowAuth" mode="new">
-                    <set-url>https://hmi-shared-kv-dev.vault.azure.net/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
+                    <set-url>https://#{keyVaultHost}#/secrets/hmi-servicenow-auth?api-version=7.0</set-url>
                     <set-method>GET</set-method>
                     <authentication-managed-identity resource="https://vault.azure.net" />
                 </send-request>
                 <send-request ignore-error="false" timeout="20" response-variable-name="serviceNow" mode="new">
-                    <set-url>https://mojcppdev.service-now.com/api/now/table/incident?sysparm_fields=number</set-url>
+                    <set-url>https://#{snowHost}#/api/now/table/incident?sysparm_fields=number</set-url>
                     <set-method>POST</set-method>
                     <set-header name="Authorization" exists-action="override">
                         <value>@("Basic " + ((IResponse)context.Variables["snowAuth"]).Body.As


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1123


### Change description ###

Analysis
All HMI Health Check endpoints need to be modified to raise Service Now incident when HTTP 200 code is not returned from the back-end service.
Development
The Outbound sections of each policy need to be modified so that all other codes, apart from HTTP 200, generate incident ticket. This can be done by creation of following in the Outbound policy section:
If code is 200 then do nothing
Otherwise raise Service Now incident via its RESTfull API

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
