### PR TITLE
disabled testSuccessfulGetSessionForRequestSessionTypeAndJurisdiction

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/sessions/SessionsLookUpTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/sessions/SessionsLookUpTest.java
@@ -103,11 +103,12 @@ public class SessionsLookUpTest extends FunctionalTest {
                 queryParameters);
     }
 
+    @Disabled
     @Test
     public void testSuccessfulGetSessionForRequestSessionTypeAndJurisdiction() {
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put("requestSessionType", "CJ");
-        queryParameters.put("requestJurisdiction", "AA");
+        queryParameters.put("requestJurisdiction", "CIV");
         headersAsMap.put("Destination-System", "SNL");
         sessionsLookUpSteps.checkSessionsForAllTheRelevantQueryParameters(sessionsRootContext,
                 headersAsMap,


### PR DESCRIPTION
### Change description ###
disabled testSuccessfulGetSessionForRequestSessionTypeAndJurisdiction

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
