### PR TITLE
HMIS-1204 - account for BST

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -19,7 +19,7 @@ resources:
       endpoint: hmcts
 
 schedules:
-- cron: "0 18 * * *"
+- cron: "0 17 * * *"
   displayName: Nightly
   branches:
     include:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMIS-1204


### Change description ###
Change nightly build schedule to run one hour sooner to account for BST time.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
