### PR TITLE
HMIS-1202 Enable eLink functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/people/PeopleTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/futurehearings/hmi/functional/people/PeopleTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.futurehearings.hmi.functional.people;
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,7 +49,6 @@ class PeopleTest extends FunctionalTest {
     }
 
     @Test
-    @Disabled
     void testPeopleLookUp() {
         Map<String, String> queryParameters = new ConcurrentHashMap<>();
         queryParameters.put("updated_since", "2019-01-29");
@@ -67,7 +65,6 @@ class PeopleTest extends FunctionalTest {
     }
 
     @Test
-    @Disabled
     void testPersonLookUp() {
         peopleIdRootContext = String.format(peopleIdRootContext, rand.nextInt(99999999));
         headersAsMap = createStandardHmiHeader("ELINKS");


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1202

### Change description ###

eLink API V5 is working fine now, so need to enable the functional tests.

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No